### PR TITLE
Explicit tags for docker push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,8 @@ commands:
           name: Pushing Image to docker hub
           command: |
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            docker push ${DOCKHUB_ORGANISATION}/binary-static-charts
+            docker push ${DOCKHUB_ORGANISATION}/binary-static-charts:<< parameters.docker_image_tag >>
+            docker push ${DOCKHUB_ORGANISATION}/binary-static-charts:<< parameters.docker_latest_image_tag >>
   k8s_deploy:
     description: "Deploy to k8s cluster"
     parameters:


### PR DESCRIPTION
# Changes
- Give explicit tags to push (to fix `tag does not exist` error)